### PR TITLE
feat: generator support rpc utxo type

### DIFF
--- a/src/rpc/rpc-client.ts
+++ b/src/rpc/rpc-client.ts
@@ -1128,8 +1128,6 @@ export class RpcClient implements RpcEventObservable {
     const request = this.buildRequest(method, params);
     const bridgePromise = new BridgePromise<TRes>();
     this.requestPromiseMap.set(request.id ?? this.generateRandomId(), bridgePromise);
-    console.log('sending request', JSON.stringify(request));
-    console.log(`requestPromiseMap size: ${this.requestPromiseMap.size}`);
     this.ws!.send(JSON.stringify(request));
     return bridgePromise.promise;
   };
@@ -1196,8 +1194,6 @@ export class RpcClient implements RpcEventObservable {
    * @param {JsonRpcResponse<any>} res - The response from the server.
    */
   private handleResponse = (res: JsonRpcResponse<any>) => {
-    console.log('received response', JSON.stringify(res));
-    console.log(`requestPromiseMap size: ${this.requestPromiseMap.size}`);
     const bridgePromise = this.requestPromiseMap.get(res.id!);
     if (bridgePromise) {
       if (res.error) {

--- a/src/rpc/types/rpc.ts
+++ b/src/rpc/types/rpc.ts
@@ -1,4 +1,3 @@
-import { UtxoEntryReference } from '../../tx';
 import { ISubmittableJsonTransaction } from '../../tx/generator/model/submittable';
 
 /**
@@ -560,7 +559,7 @@ export interface GetUtxosByAddressesRequestMessage {
 }
 
 export interface GetUtxosByAddressesResponseMessage {
-  entries: UtxoEntryReference[];
+  entries: RpcUtxosByAddressesEntry[];
   error: RPCError | undefined;
 }
 

--- a/src/send-param.ts
+++ b/src/send-param.ts
@@ -3,6 +3,7 @@ import { Fees, GeneratorSettings, PaymentOutput, TransactionId, TransactionOutpo
 import { addressFromScriptPublicKey, kaspaToSompi } from './utils';
 import { OpCodes, ScriptBuilder } from './tx-script';
 import { NetworkId } from './consensus';
+import { RpcUtxosByAddressesEntry } from './rpc/types';
 
 const COMMIT_TX_OUTPUT_AMOUNT = kaspaToSompi(0.3);
 
@@ -117,7 +118,7 @@ class SendKrc20Params implements ITxParams {
    * @param uxtos - The UTXO entries.
    * @returns The generator settings.
    */
-  toCommitTxGeneratorSettings(uxtos: UtxoEntryReference[] = []): GeneratorSettings {
+  toCommitTxGeneratorSettings(uxtos: UtxoEntryReference[] | RpcUtxosByAddressesEntry[] = []): GeneratorSettings {
     const P2SHAddress = addressFromScriptPublicKey(
       this.script.createPayToScriptHashScript(),
       this.networkId.networkType
@@ -133,7 +134,10 @@ class SendKrc20Params implements ITxParams {
    * @param commitTxId - The commit transaction ID.
    * @returns The generator settings.
    */
-  toRevealTxGeneratorSettings(uxtos: UtxoEntryReference[] = [], commitTxId: TransactionId): GeneratorSettings {
+  toRevealTxGeneratorSettings(
+    uxtos: UtxoEntryReference[] | RpcUtxosByAddressesEntry[] = [],
+    commitTxId: TransactionId
+  ): GeneratorSettings {
     const P2SHAddress = addressFromScriptPublicKey(
       this.script.createPayToScriptHashScript(),
       this.networkId.networkType

--- a/src/tx/generator/model/settings.ts
+++ b/src/tx/generator/model/settings.ts
@@ -1,6 +1,8 @@
-import { NetworkId } from '../../../consensus';
-import { Fees, PaymentOutput, UtxoEntryReference } from '../../model';
+import { NetworkId, ScriptPublicKey } from '../../../consensus';
+import { Fees, PaymentOutput, TransactionOutpoint, UtxoEntryReference } from '../../model';
 import { Address } from '../../../address';
+import { RpcUtxosByAddressesEntry } from '../../../rpc/types';
+import { Hash } from '../../hashing';
 
 class GeneratorSettings {
   outputs: PaymentOutput[];
@@ -16,21 +18,27 @@ class GeneratorSettings {
   constructor(
     outputs: PaymentOutput | PaymentOutput[],
     changeAddress: Address | string,
-    entries: UtxoEntryReference[],
+    entries: UtxoEntryReference[] | RpcUtxosByAddressesEntry[],
     networkId: NetworkId | string,
     priorityFee?: Fees | bigint,
-    priorityEntries?: UtxoEntryReference[],
+    priorityEntries?: UtxoEntryReference[] | RpcUtxosByAddressesEntry[],
     sigOpCount?: number,
     minimumSignatures?: number,
     payload?: Uint8Array
   ) {
     this.outputs = outputs instanceof PaymentOutput ? [outputs] : outputs;
     this.changeAddress = changeAddress instanceof Address ? changeAddress : Address.fromString(changeAddress);
-    this.entries = entries;
+    this.entries = [...entries].map((entry) => {
+      return entry instanceof UtxoEntryReference ? entry : this.rpcUtxosByAddressesEntryToUtxoEntryReference(entry);
+    });
     this.networkId = networkId instanceof NetworkId ? networkId : NetworkId.fromString(networkId);
     this.priorityFee = this.priorityFee =
       priorityFee instanceof Fees ? priorityFee : priorityFee !== undefined ? new Fees(priorityFee) : undefined;
-    this.priorityEntries = priorityEntries ? [...priorityEntries] : undefined;
+    this.priorityEntries = priorityEntries
+      ? [...priorityEntries].map((entry) => {
+          return entry instanceof UtxoEntryReference ? entry : this.rpcUtxosByAddressesEntryToUtxoEntryReference(entry);
+        })
+      : undefined;
     this.sigOpCount = sigOpCount ?? 1;
     this.minimumSignatures = minimumSignatures ?? 1;
     this.payload = payload;
@@ -40,6 +48,23 @@ class GeneratorSettings {
     this.priorityFee = priorityFee instanceof Fees ? priorityFee : new Fees(priorityFee);
     return this;
   }
+
+  /**
+   * Converts an RpcUtxosByAddressesEntry to a UtxoEntryReference.
+   *
+   * @param {RpcUtxosByAddressesEntry} utxo - The UTXO entry to convert.
+   * @returns {UtxoEntryReference} The converted UTXO entry reference.
+   */
+  rpcUtxosByAddressesEntryToUtxoEntryReference = (utxo: RpcUtxosByAddressesEntry): UtxoEntryReference => {
+    return new UtxoEntryReference(
+      Address.fromString(utxo.address),
+      new TransactionOutpoint(Hash.fromString(utxo.outpoint!.transactionId), utxo.outpoint!.index),
+      BigInt(utxo.utxoEntry?.amount ?? 0),
+      ScriptPublicKey.fromHex(utxo.utxoEntry!.scriptPublicKey!),
+      BigInt(utxo.utxoEntry?.blockDaaScore ?? 0),
+      utxo.utxoEntry?.isCoinbase ?? false
+    );
+  };
 }
 
 export { GeneratorSettings };

--- a/src/tx/generator/model/settings.ts
+++ b/src/tx/generator/model/settings.ts
@@ -48,7 +48,6 @@ class GeneratorSettings {
     this.priorityFee = priorityFee instanceof Fees ? priorityFee : new Fees(priorityFee);
     return this;
   }
-
   /**
    * Converts an RpcUtxosByAddressesEntry to a UtxoEntryReference.
    *
@@ -56,13 +55,16 @@ class GeneratorSettings {
    * @returns {UtxoEntryReference} The converted UTXO entry reference.
    */
   rpcUtxosByAddressesEntryToUtxoEntryReference = (utxo: RpcUtxosByAddressesEntry): UtxoEntryReference => {
+    if (!utxo.outpoint?.transactionId || !utxo.utxoEntry?.scriptPublicKey) {
+      throw new Error("Invalid RpcUtxosByAddressesEntry: Missing outpoint or script public key.");
+    }
     return new UtxoEntryReference(
       Address.fromString(utxo.address),
-      new TransactionOutpoint(Hash.fromString(utxo.outpoint!.transactionId), utxo.outpoint!.index),
-      BigInt(utxo.utxoEntry?.amount ?? 0),
-      ScriptPublicKey.fromHex(utxo.utxoEntry!.scriptPublicKey!),
-      BigInt(utxo.utxoEntry?.blockDaaScore ?? 0),
-      utxo.utxoEntry?.isCoinbase ?? false
+      new TransactionOutpoint(Hash.fromString(utxo.outpoint.transactionId), utxo.outpoint.index),
+      BigInt(utxo.utxoEntry.amount ?? 0),
+      ScriptPublicKey.fromHex(utxo.utxoEntry.scriptPublicKey),
+      BigInt(utxo.utxoEntry.blockDaaScore ?? 0),
+      utxo.utxoEntry.isCoinbase ?? false
     );
   };
 }

--- a/src/tx/generator/model/signable-tx.ts
+++ b/src/tx/generator/model/signable-tx.ts
@@ -126,6 +126,7 @@ class SignableTransaction {
    */
   toSubmittableJsonTx(): ISubmittableJsonTransaction {
     return {
+      verb: undefined,
       id: this.id.toString(),
       version: this.tx.version,
       inputs: this.tx.inputs.map((input) => ({

--- a/tests/rpc/resolver.test.ts
+++ b/tests/rpc/resolver.test.ts
@@ -85,12 +85,12 @@ describe('Resolver', () => {
     await expect(resolver['fetch'](NetworkId.Testnet10)).rejects.toThrowError(/Network error/);
   });
 
-  it('json resolver real', async () => {
-    console.time('getEndpoint');
-    const resolver = new Resolver(null, true);
-    const endpoints = await resolver.getAllNodeEndpoints(NetworkId.Testnet11);
-    console.log(endpoints);
-    console.timeEnd('getEndpoint');
-    expect(endpoints).length.greaterThan(0);
-  }, 1000000);
+  // it('json resolver real', async () => {
+  //   console.time('getEndpoint');
+  //   const resolver = new Resolver(null, true);
+  //   const endpoints = await resolver.getAllNodeEndpoints(NetworkId.Testnet11);
+  //   console.log(endpoints);
+  //   console.timeEnd('getEndpoint');
+  //   expect(endpoints).length.greaterThan(0);
+  // }, 1000000);
 });

--- a/tests/rpc/resolver.test.ts
+++ b/tests/rpc/resolver.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
-import { Resolver, tryParseResolvers } from '../src/rpc/resolver';
-import { NetworkId, NetworkType } from '../src/consensus/network';
+import { Resolver, tryParseResolvers } from '../../src/rpc/resolver';
+import { NetworkId, NetworkType } from '../../src/consensus/network';
 
 describe('Resolver', () => {
   const mockToml = `
@@ -85,12 +85,12 @@ describe('Resolver', () => {
     await expect(resolver['fetch'](NetworkId.Testnet10)).rejects.toThrowError(/Network error/);
   });
 
-  // it('json resolver real', async () => {
-  //   console.time('getEndpoint');
-  //   const resolver = new Resolver(null, true);
-  //   const endpoints = await resolver.getAllNodeEndpoints(NetworkId.Testnet11);
-  //   console.log(endpoints);
-  //   console.timeEnd('getEndpoint');
-  //   expect(endpoints).length.greaterThan(0);
-  // }, 1000000);
+  it('json resolver real', async () => {
+    console.time('getEndpoint');
+    const resolver = new Resolver(null, true);
+    const endpoints = await resolver.getAllNodeEndpoints(NetworkId.Testnet11);
+    console.log(endpoints);
+    console.timeEnd('getEndpoint');
+    expect(endpoints).length.greaterThan(0);
+  }, 1000000);
 });

--- a/tests/tx/data/single-utxo.json
+++ b/tests/tx/data/single-utxo.json
@@ -1,0 +1,15 @@
+[
+  {
+    "address": "kaspatest:qzw9xtuu63l4q3kxpgseut2r9z3xp9t29uhz7smwymendlhptt5fs77lmj7ys",
+    "outpoint": {
+      "index": 0,
+      "transactionId": "3cf08c7b053b9110000a513ba03399b15be3c97631fd55517d0c00abf59e0f09"
+    },
+    "utxoEntry": {
+      "amount": 100000000000,
+      "blockDaaScore": 311357067,
+      "isCoinbase": false,
+      "scriptPublicKey": "0000209c532f9cd47f5046c60a219e2d4328a260956a2f2e2f436e26f336fee15ae898ac"
+    }
+  }
+]

--- a/tests/tx/generator-krc20.test.ts
+++ b/tests/tx/generator-krc20.test.ts
@@ -91,7 +91,7 @@ describe('Generator kas tx', () => {
   });
 });
 
-describe('Generator specific settings', () => {
+describe('Generator specific test cases', () => {
   it('should generate transactions without errors', () => {
     const sendKrc20Params = new SendKrc20Params(
       'kaspatest:qzw9xtuu63l4q3kxpgseut2r9z3xp9t29uhz7smwymendlhptt5fs77lmj7ys',

--- a/tests/tx/generator-krc20.test.ts
+++ b/tests/tx/generator-krc20.test.ts
@@ -3,7 +3,9 @@ import { Fees, Generator, SignableTransaction } from '../../src/tx';
 import { kaspaToSompi, NetworkId, NetworkType, SendKrc20Params } from '../../src';
 import { parseTxsFromFile, parseUtxosFromFile } from './test-helper';
 import { SignedType } from '../../src/tx/generator/model/signed-tx';
+import fs from 'fs';
 import path from 'path';
+import { RpcUtxosByAddressesEntry } from '../../src/rpc/types';
 
 const SENDDER_PK = '5cd51b74226a845b8c757494136659997db1aaedf34c528e297f849f0fe87faf';
 const SENDER_ADDR = 'kaspatest:qzzzvv57j68mcv3rsd2reshhtv4rcw4xc8snhenp2k4wu4l30jfjxlgfr8qcz';
@@ -86,5 +88,34 @@ describe('Generator kas tx', () => {
     const submitableTx = signedTx.toSubmittableJsonTx();
 
     expect(submitableTx.id).equals(resultSendKrc20RevealTxSigned[0].id.toHex());
+  });
+});
+
+describe('Generator specific settings', () => {
+  it('should generate transactions without errors', () => {
+    const sendKrc20Params = new SendKrc20Params(
+      'kaspatest:qzw9xtuu63l4q3kxpgseut2r9z3xp9t29uhz7smwymendlhptt5fs77lmj7ys',
+      200000000n,
+      'kaspatest:qq5zy4rfsrzllchkd7myamqqe83k55qykmpc8exyt5a4qn798f3hjx24kkevw',
+      'KAST',
+      new NetworkId(NetworkType.Testnet, 10),
+      kaspaToSompi(0.3),
+      new Fees(0n)
+    );
+    const data = fs.readFileSync(path.resolve(__dirname, './data/single-utxo.json'), 'utf-8');
+    const utxos = JSON.parse(data) as RpcUtxosByAddressesEntry[];
+    const settings = sendKrc20Params.toCommitTxGeneratorSettings(utxos);
+    const generator = new Generator(settings);
+    const transactions = new Array<SignableTransaction>();
+
+    while (true) {
+      const transaction = generator.generateTransaction();
+      if (transaction === undefined) {
+        break;
+      }
+      transactions.push(transaction);
+    }
+
+    expect(transactions.length).toBeGreaterThan(0);
   });
 });

--- a/tests/tx/test-helper.ts
+++ b/tests/tx/test-helper.ts
@@ -87,8 +87,11 @@ function parseUtxosFromFile(file: string): UtxoEntryReference[] {
   const utxos = parseWithBigInt(fileContent);
 
   return utxos.map((utxo: any) => {
+    let address = utxo.address.prefix
+      ? Address.fromString(utxo.address.prefix + ':' + utxo.address.payload)
+      : Address.fromString(utxo.address);
     return new UtxoEntryReference(
-      Address.fromString(utxo.address.prefix + ':' + utxo.address.payload),
+      address,
       new TransactionOutpoint(Hash.fromHex(utxo.outpoint.transactionId), utxo.outpoint.index),
       BigInt(utxo.amount),
       new ScriptPublicKey(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced UTXO entry handling with support for new `RpcUtxosByAddressesEntry` type
	- Added flexibility in transaction generation methods
	- Introduced a new property in transaction submission structure

- **Bug Fixes**
	- Improved WebSocket connection robustness in RPC client
	- Updated address parsing in test utilities

- **Refactor**
	- Renamed WebSocket client property for improved clarity
	- Updated method signatures to support multiple UTXO entry types

- **Tests**
	- Added new test cases for transaction generation
	- Included a new sample UTXO JSON file for testing
	- Uncommented existing test for JSON resolver functionality
<!-- end of auto-generated comment: release notes by coderabbit.ai -->