### PR TITLE
feat(krc20): add transfer support for issue krc20

### DIFF
--- a/src/krc20/tx-params.ts
+++ b/src/krc20/tx-params.ts
@@ -278,8 +278,15 @@ class Krc20TransferParams extends Krc20TxParams {
    * @returns The script builder.
    */
   get script(): ScriptBuilder {
-    const { tick, to, amount } = this.options as Krc20TransferOptions;
-    const data = { p: 'krc-20', op: 'transfer', tick, amt: amount.toString(), to } as any;
+    const { tick, ca, to, amount } = this.options as Krc20TransferOptions;
+    const data = {
+      p: 'krc-20',
+      op: 'transfer',
+      ...(tick && { tick }),
+      ...(ca && { ca }),
+      amt: amount.toString(),
+      to
+    } as any;
     return this.getScriptBuilder(data);
   }
 }

--- a/tests/krc20/tx-params.test.ts
+++ b/tests/krc20/tx-params.test.ts
@@ -93,6 +93,18 @@ describe('Krc20TxParams', () => {
       expect(params.options.tick).toBe('TEST');
     });
 
+    it('should create a valid Krc20TransferParams instance with ca field', () => {
+      const options = {
+        ca: '1234567890123456789012345678901234567890123456789012345678901234', // 64 chars
+        to: 'kaspatest:qp3leh6s6t85put26yfy7c50ragzk266s700wtxvyrmjzznnlglg2qs70c3ls',
+        amount: 100n
+      };
+      const params = new Krc20TransferParams(senderAddress, networkId, priorityFee, options);
+      expect(params).toBeInstanceOf(Krc20TransferParams);
+      expect('ca' in params.options).toBeTruthy();
+      expect((params.options as any).ca).toBe('1234567890123456789012345678901234567890123456789012345678901234');
+    });
+
     it('should throw an error for amount less than or equal to zero', () => {
       const options = {
         tick: 'TEST',
@@ -112,6 +124,37 @@ describe('Krc20TxParams', () => {
       };
       expect(() => new Krc20TransferParams(senderAddress, networkId, priorityFee, options)).toThrow(
         'Invalid address format'
+      );
+    });
+
+    it('should throw an error for ca with invalid length', () => {
+      const options = {
+        ca: '123456789012345678901234567890123456789012345678901234567890123', // 63 chars (too short)
+        to: 'kaspatest:qp3leh6s6t85put26yfy7c50ragzk266s700wtxvyrmjzznnlglg2qs70c3ls',
+        amount: 100n
+      };
+      expect(() => new Krc20TransferParams(senderAddress, networkId, priorityFee, options)).toThrow(
+        'Invalid ca format'
+      );
+
+      const options2 = {
+        ca: '12345678901234567890123456789012345678901234567890123456789012345', // 65 chars (too long)
+        to: 'kaspatest:qp3leh6s6t85put26yfy7c50ragzk266s700wtxvyrmjzznnlglg2qs70c3ls',
+        amount: 100n
+      };
+      expect(() => new Krc20TransferParams(senderAddress, networkId, priorityFee, options2)).toThrow(
+        'Invalid ca format'
+      );
+    });
+
+    it('should throw an error for ca with invalid characters', () => {
+      const options = {
+        ca: '12345678901234567890123456789012345678901234567890123456789012!', // contains special character
+        to: 'kaspatest:qp3leh6s6t85put26yfy7c50ragzk266s700wtxvyrmjzznnlglg2qs70c3ls',
+        amount: 100n
+      };
+      expect(() => new Krc20TransferParams(senderAddress, networkId, priorityFee, options)).toThrow(
+        'Invalid ca format'
       );
     });
   });


### PR DESCRIPTION
## Overview
This pull request introduces support for an optional `ca` (contract address) field as an alternative to the `tick` field in KRC-20 transfer operations, along with comprehensive validation and testing.

## Changes Made

### Core Functionality
- **Modified `Krc20TransferOptions` interface**: Made `tick` field optional and added optional `ca` field
- **Enhanced validation logic**: Added validation for the `ca` field requiring exactly 64 alphanumeric characters
- **Updated transfer script generation**: Modified script builder to conditionally include either `tick` or `ca` field in the transfer data

### Validation Rules
- `ca` field must be exactly 64 characters long
- `ca` field must contain only alphanumeric characters (a-z, A-Z, 0-9)
- Either `tick` or `ca` must be provided (mutual exclusivity with fallback)
- Maintains existing `tick` validation (4-6 alphabetic characters)

### Testing
- **Success case**: Validates creation of transfer parameters with valid 64-character `ca` field
- **Failure cases**: 
  - Invalid length (too short/too long)
  - Invalid characters (special characters)
  - Comprehensive edge case coverage

## Impact
- Provides flexibility for KRC-20 transfers to use contract addresses instead of ticker symbols
- Maintains backward compatibility with existing `tick`-based transfers
- Ensures data integrity through strict validation rules
- No breaking changes to existing API

This enhancement expands the KRC-20 transfer functionality while maintaining robust validation and comprehensive test coverage.
